### PR TITLE
Fix JS for strict mode syntax error

### DIFF
--- a/vendor/assets/javascripts/scrollinity.js
+++ b/vendor/assets/javascripts/scrollinity.js
@@ -1,5 +1,7 @@
 $(document).ready(function(){
 
+  'use strict';
+
   function load_new_items(){
     var sign = load_path.indexOf('?') >= 0 ? '&' : '?'
     $.get(load_path + sign + 'page=' + (++page_num), function(data, e) {

--- a/vendor/assets/javascripts/scrollinity.js
+++ b/vendor/assets/javascripts/scrollinity.js
@@ -1,10 +1,10 @@
 $(document).ready(function(){
 
   function load_new_items(){
-    sign = load_path.indexOf('?') >= 0 ? '&' : '?'
+    var sign = load_path.indexOf('?') >= 0 ? '&' : '?'
     $.get(load_path + sign + 'page=' + (++page_num), function(data, e) {
       if(data.length < 5) {
-        page_num = 0;
+        var page_num = 0;
         return false;
       }
       data_container.append(data);
@@ -22,11 +22,11 @@ $(document).ready(function(){
   }
 
   if($('*[data-scrollinity-path]').length > 0) {
-    var page_num = 1
-    load_path = $('*[data-scrollinity-path]').data('scrollinity-path');
-    loading_pic = $('*[data-scrollinity-loading-pic]');
-    data_container = $('#' + $('*[data-scrollinity-data-container]').data('scrollinity-data-container'));
-    bottom_px_limit = $('*[data-scrollinity-bottom-px-limit]').data('scrollinity-bottom-px-limit');
+    var page_num        = 1
+    var load_path       = $('*[data-scrollinity-path]').data('scrollinity-path');
+    var loading_pic     = $('*[data-scrollinity-loading-pic]');
+    var data_container  = $('#' + $('*[data-scrollinity-data-container]').data('scrollinity-data-container'));
+    var bottom_px_limit = $('*[data-scrollinity-bottom-px-limit]').data('scrollinity-bottom-px-limit');
 
     $(window).on('scroll', function(){
       if(loading_hidden() && near_bottom()) {

--- a/vendor/assets/javascripts/scrollinity.js
+++ b/vendor/assets/javascripts/scrollinity.js
@@ -1,4 +1,26 @@
 $(document).ready(function(){
+
+  function load_new_items(){
+    sign = load_path.indexOf('?') >= 0 ? '&' : '?'
+    $.get(load_path + sign + 'page=' + (++page_num), function(data, e) {
+      if(data.length < 5) {
+        page_num = 0;
+        return false;
+      }
+      data_container.append(data);
+    }).complete(function() {
+      loading_pic.hide();
+    });
+  }
+
+  function loading_hidden(){
+    return !loading_pic.is(':visible');
+  }
+
+  function near_bottom(){
+    return $(window).scrollTop() > $(document).height() - $(window).height() - bottom_px_limit;
+  }
+
   if($('*[data-scrollinity-path]').length > 0) {
     var page_num = 1
     load_path = $('*[data-scrollinity-path]').data('scrollinity-path');
@@ -14,26 +36,5 @@ $(document).ready(function(){
         }
       }
     });
-
-    function load_new_items(){
-      sign = load_path.indexOf('?') >= 0 ? '&' : '?'
-      $.get(load_path + sign + 'page=' + (++page_num), function(data, e) {
-        if(data.length < 5) {
-          page_num = 0;
-          return false;
-        }
-        data_container.append(data);
-      }).complete(function() {
-        loading_pic.hide();
-      });
-    }
-
-    function loading_hidden(){
-      return !loading_pic.is(':visible');
-    }
-
-    function near_bottom(){
-      return $(window).scrollTop() > $(document).height() - $(window).height() - bottom_px_limit;
-    }
   }
 });

--- a/vendor/assets/javascripts/scrollinity.js
+++ b/vendor/assets/javascripts/scrollinity.js
@@ -30,7 +30,7 @@ $(document).ready(function(){
     var data_container  = $('#' + $('*[data-scrollinity-data-container]').data('scrollinity-data-container'));
     var bottom_px_limit = $('*[data-scrollinity-bottom-px-limit]').data('scrollinity-bottom-px-limit');
 
-    $(window).on('scroll', function(){
+    $(window).on('scroll.scrollinity', function(){
       if(loading_hidden() && near_bottom()) {
         if(page_num > 0) {
           loading_pic.show();
@@ -39,4 +39,8 @@ $(document).ready(function(){
       }
     });
   }
+  else {
+    $(window).off('scroll.scrollinity');
+  }
+
 });


### PR DESCRIPTION
When javascript is running in strict mode, functions are required to be declared only at the top level or immediately within another function.

This pull request fixes the JS to be compatible with strict mode.

Here is the error as recorded from Firebug:

```
SyntaxError: in strict mode code, functions may be declared only at top level or immediately within another function
function load_new_items(){ 
... 
```
